### PR TITLE
chore(ci): update PyPI publish workflow for BabelDOC

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/yadt
+      url: https://pypi.org/p/BabelDOC
 
     permissions:
       id-token: write
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/yadt
+      url: https://test.pypi.org/p/BabelDOC
 
     permissions:
       id-token: write


### PR DESCRIPTION
- Rename project references from 'yadt' to 'BabelDOC' in publish workflows
- Update PyPI and TestPyPI environment URLs