### PR TITLE
fix: Temporarily disable CoreML execution provider

### DIFF
--- a/babeldoc/docvision/doclayout.py
+++ b/babeldoc/docvision/doclayout.py
@@ -76,7 +76,7 @@ os_name = platform.system()
 
 providers = []
 
-if os_name == "Darwin":  # Temporarily disable CoreML due to batch inference issues
+if os_name == "Darwin" and False:  # Temporarily disable CoreML due to some issues
     providers.append(
         (
             "CoreMLExecutionProvider",


### PR DESCRIPTION
- Add `and False` condition to prevent CoreML provider from being used