### PR TITLE
feat(pdf): remove --use-side-by-side-dual option and keep only --use-alternating-pages-dual

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ uv run babeldoc --bing --files example.pdf --files example2.pdf
 - `--dual-translate-first`: Put translated pages first in dual PDF mode (default: original pages first)
 - `--disable-rich-text-translate`: Disable rich text translation (may help improve compatibility with some PDFs)
 - `--enhance-compatibility`: Enable all compatibility enhancement options (equivalent to --skip-clean --dual-translate-first --disable-rich-text-translate)
-- `--use-side-by-side-dual`: Use side-by-side mode for dual PDF (default). Original and translated pages are shown side by side on the same page.
-- `--use-alternating-pages-dual`: Use alternating pages mode for dual PDF. Original and translated pages are arranged in alternate order.
+- `--use-alternating-pages-dual`: Use alternating pages mode for dual PDF. When enabled, original and translated pages are arranged in alternate order. When disabled (default), original and translated pages are shown side by side on the same page.
 
 > [!TIP]
 > - Both `--skip-clean` and `--dual-translate-first` may help improve compatibility with some PDF readers

--- a/babeldoc/document_il/backend/pdf_creater.py
+++ b/babeldoc/document_il/backend/pdf_creater.py
@@ -482,27 +482,23 @@ class PDFCreater:
                 original_pdf = pymupdf.open(self.original_pdf_path)
                 translated_pdf = pdf
 
-                # Choose between side-by-side and alternating pages format
+                # Choose between alternating pages and side-by-side format
                 # Default to side-by-side if not specified
-                use_side_by_side = getattr(
-                    translation_config,
-                    "use_side_by_side_dual",
-                    True,
-                )
+                use_alternating_pages = translation_config.use_alternating_pages_dual
 
-                if use_side_by_side:
+                if use_alternating_pages:
+                    # Create a dual PDF with alternating pages (original and translation)
+                    dual = self.create_alternating_pages_dual_pdf(
+                        self.original_pdf_path,
+                        translated_pdf,
+                        translation_config,
+                    )
+                else:
                     # Create a dual PDF with side-by-side pages (original and translation)
                     dual = self.create_side_by_side_dual_pdf(
                         original_pdf,
                         translated_pdf,
                         dual_out_path,
-                        translation_config,
-                    )
-                else:
-                    # Create a dual PDF with alternating pages (original and translation)
-                    dual = self.create_alternating_pages_dual_pdf(
-                        self.original_pdf_path,
-                        translated_pdf,
                         translation_config,
                     )
 

--- a/babeldoc/main.py
+++ b/babeldoc/main.py
@@ -177,15 +177,9 @@ def create_parser():
         help="Enable all compatibility enhancement options (equivalent to --skip-clean --dual-translate-first --disable-rich-text-translate)",
     )
     translation_params.add_argument(
-        "--use-side-by-side-dual",
-        default=True,
-        action="store_true",
-        help="Use side-by-side mode for dual PDF (default). When enabled, original and translated pages are shown side by side.",
-    )
-    translation_params.add_argument(
         "--use-alternating-pages-dual",
-        dest="use_side_by_side_dual",
-        action="store_false",
+        default=False,
+        action="store_true",
         help="Use alternating pages mode for dual PDF. When enabled, original and translated pages are arranged in alternate order.",
     )
     translation_params.add_argument(
@@ -438,7 +432,7 @@ async def main():
             dual_translate_first=args.dual_translate_first,
             disable_rich_text_translate=args.disable_rich_text_translate,
             enhance_compatibility=args.enhance_compatibility,
-            use_side_by_side_dual=args.use_side_by_side_dual,
+            use_alternating_pages_dual=args.use_alternating_pages_dual,
             report_interval=args.report_interval,
             min_text_length=args.min_text_length,
         )

--- a/babeldoc/translation_config.py
+++ b/babeldoc/translation_config.py
@@ -37,7 +37,7 @@ class TranslationConfig:
         enhance_compatibility: bool = False,  # 增强兼容性模式
         report_interval: float = 0.1,  # Progress report interval in seconds
         min_text_length: int = 5,  # Minimum text length to translate
-        use_side_by_side_dual: bool = True,  # 是否使用拼版式双语 PDF（并排显示原文和译文）
+        use_alternating_pages_dual: bool = False,  # 是否使用交替页式双语 PDF（交替显示原文和译文）
     ):
         self.input_file = input_file
         self.translator = translator
@@ -63,7 +63,7 @@ class TranslationConfig:
         )
         self.report_interval = report_interval
         self.min_text_length = min_text_length
-        self.use_side_by_side_dual = use_side_by_side_dual
+        self.use_alternating_pages_dual = use_alternating_pages_dual
         if progress_monitor:
             if progress_monitor.cancel_event is None:
                 progress_monitor.cancel_event = threading.Event()


### PR DESCRIPTION
## Changes

- Removed the `--use-side-by-side-dual` command line option

- Updated the `--use-alternating-pages-dual` option to make it a standalone option (default value is False)

- Renamed the `use_side_by_side_dual` parameter to `use_alternating_pages_dual` in the configuration

- Updated the PDF creator logic to use the new parameter

- Updated documentation in README.md

## Testing

The following scenarios have been verified:

- By default, continue to create bilingual PDFs using side-by-side mode

- When using the `--use-alternating-pages-dual` option, create bilingual PDFs using alternating pages mode