### PR TITLE
fix(pdf_creater): add exception handling for show_pdf_page operations

### DIFF
--- a/babeldoc/document_il/backend/pdf_creater.py
+++ b/babeldoc/document_il/backend/pdf_creater.py
@@ -203,21 +203,37 @@ class PDFCreater:
             if translation_config.dual_translate_first:
                 # Show translated page on left and original on right
                 rect_left, rect_right = rect_right, rect_left
-
-            # Show original page on left and translated on right (default)
-            dual_page.show_pdf_page(
-                rect_left,
-                original_pdf,
-                page_id,
-                keep_proportion=True,
-            )
-            dual_page.show_pdf_page(
-                rect_right,
-                translated_pdf,
-                page_id,
-                keep_proportion=True,
-            )
-
+            try:
+                # Show original page on left and translated on right (default)
+                dual_page.show_pdf_page(
+                    rect_left,
+                    original_pdf,
+                    page_id,
+                    keep_proportion=True,
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to show original page on left and translated on right (default). "
+                    f"Page ID: {page_id}. "
+                    f"Original PDF: {self.original_pdf_path}. "
+                    f"Translated PDF: {translation_config.input_file}. ",
+                    exc_info=e,
+                )
+            try:
+                dual_page.show_pdf_page(
+                    rect_right,
+                    translated_pdf,
+                    page_id,
+                    keep_proportion=True,
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to show translated page on left and original on right. "
+                    f"Page ID: {page_id}. "
+                    f"Original PDF: {self.original_pdf_path}. "
+                    f"Translated PDF: {translation_config.input_file}. ",
+                    exc_info=e,
+                )
         return dual
 
     def create_alternating_pages_dual_pdf(


### PR DESCRIPTION
## Description
This PR adds proper exception handling and logging for `show_pdf_page` operations in the dual PDF creation process. 

## Changes
- Added try-except blocks around `show_pdf_page` calls
- Added detailed error logging with page ID and file information 
- Improved error handling to ensure the process continues even if rendering of specific pages fails

## Testing
The code has been tested with problematic PDFs that previously caused rendering issues.

## Related Issues
Resolves issues with PDF rendering errors during dual PDF creation.