### PR TITLE
feat(il_creater): Skip characters with zero font size during IL creation

### DIFF
--- a/babeldoc/document_il/frontend/il_creater.py
+++ b/babeldoc/document_il/frontend/il_creater.py
@@ -313,6 +313,12 @@ class ILCreater:
             pdf_style=pdf_style,
             xobj_id=char.xobj_id,
         )
+        if pdf_style.font_size == 0.0:
+            logger.warning(
+                "Font size is 0.0 for character %s. Skip it.",
+                char_unicode,
+            )
+            return
         self.current_page.pdf_character.append(pdf_char)
 
     def create_il(self):


### PR DESCRIPTION
This PR adds a defensive check to skip characters with zero font size during the IL creation process. Previously, these characters were processed normally, which could potentially lead to rendering issues or errors in downstream processing.
