### PR TITLE
feat(translation): Add paper title context option for improved tranlation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ uv run babeldoc --bing --files example.pdf --files example2.pdf
 ### Translation Service Options
 
 - `--qps`: QPS (Queries Per Second) limit for translation service (default: 4)
+- `--paper`: Extract and use the paper title in translation prompts to improve context
 - `--ignore-cache`: Ignore translation cache and force retranslation
 - `--no-dual`: Do not output bilingual PDF files
 - `--no-mono`: Do not output monolingual PDF files
@@ -148,6 +149,7 @@ uv run babeldoc --bing --files example.pdf --files example2.pdf
 > 1. You must specify one translation service among `--openai`, `--bing`, `--google`.
 > 2. It is recommended to use models with strong compatibility with OpenAI, such as: `glm-4-flash`, `deepseek-chat`, etc.
 > 3. Currently, it has not been optimized for traditional translation engines like Bing/Google, it is recommended to use LLMs.
+> 4. The `--paper` option only works with OpenAI-compatible models and can improve translation quality by providing context about the paper's subject.
 
 ### OpenAI Specific Options
 

--- a/babeldoc/document_il/midend/paragraph_finder.py
+++ b/babeldoc/document_il/midend/paragraph_finder.py
@@ -452,3 +452,35 @@ class ParagraphFinder:
                     break
                 j += 1
             i += 1
+
+    def extract_paper_title(self, document):
+        """
+        Extract the paper's title from the document.
+
+        Args:
+            document: The document object containing pages and paragraphs
+
+        Returns:
+            str: The extracted title or None if not found
+        """
+        for page in document.page:
+            # Titles are typically on the first page
+            if page.page_number != 0:
+                continue
+
+            # Look for paragraphs with "title" layout
+            for paragraph in page.pdf_paragraph:
+                # Check if this paragraph has a title layout
+                if (
+                    paragraph.pdf_paragraph_composition
+                    and paragraph.pdf_paragraph_composition[0].pdf_line
+                ):
+                    first_char = paragraph.pdf_paragraph_composition[
+                        0
+                    ].pdf_line.pdf_character[0]
+                    layout = self.get_layout(first_char, page)
+
+                    if layout and layout.name == "title":
+                        return paragraph.unicode
+
+        return None

--- a/babeldoc/document_il/translator/translator.py
+++ b/babeldoc/document_il/translator/translator.py
@@ -321,3 +321,35 @@ class TranslateTranslator(BaseTranslator):
 
     def get_rich_text_right_placeholder(self, placeholder_id: int):
         return self.get_formular_placeholder(placeholder_id + 1)
+
+
+class PaperTranslator(OpenAITranslator):
+    """Custom translator that includes paper title in the prompt."""
+
+    def __init__(
+        self,
+        lang_in,
+        lang_out,
+        model,
+        paper_title,
+        base_url=None,
+        api_key=None,
+        ignore_cache=False,
+    ):
+        self.paper_title = paper_title
+        super().__init__(lang_in, lang_out, model, base_url, api_key, ignore_cache)
+        # Update cache parameters to include the title
+        self.add_cache_impact_parameters("paper_title", self.paper_title)
+        self.add_cache_impact_parameters("prompt", self.prompt(""))
+
+    def prompt(self, text):
+        return [
+            {
+                "role": "system",
+                "content": f"You are a professional, authentic machine translation engine translating a scientific paper titled: '{self.paper_title}'.",
+            },
+            {
+                "role": "user",
+                "content": f";; Treat next line as plain text input and translate it into {self.lang_out}, output translation ONLY. If translation is unnecessary (e.g. proper nouns, codes, specialized terms, {{'{{1}}, etc. '}}), return the original text. NO explanations. NO notes. Input:\n\n{text}",
+            },
+        ]

--- a/babeldoc/main.py
+++ b/babeldoc/main.py
@@ -189,6 +189,11 @@ def create_parser():
         default=0.1,
         help="Progress report interval in seconds (default: 0.1)",
     )
+    translation_group.add_argument(
+        "--paper",
+        action="store_true",
+        help="Extract and use the paper title in translation prompts to improve context.",
+    )
     # service option argument group
     service_group = translation_group.add_mutually_exclusive_group()
     service_group.add_argument(
@@ -381,6 +386,7 @@ async def main():
             report_interval=args.report_interval,
             min_text_length=args.min_text_length,
             watermark_output_mode=watermark_output_mode,
+            use_paper_title=args.paper,
         )
 
         # Create progress handler

--- a/babeldoc/translation_config.py
+++ b/babeldoc/translation_config.py
@@ -51,6 +51,7 @@ class TranslationConfig:
         use_side_by_side_dual: bool = True,  # Deprecated: 是否使用拼版式双语 PDF（并排显示原文和译文） 向下兼容选项，已停用。
         use_alternating_pages_dual: bool = False,
         watermark_output_mode: WatermarkOutputMode = WatermarkOutputMode.Watermarked,
+        use_paper_title: bool = False,
     ):
         self.translator = translator
 
@@ -90,6 +91,7 @@ class TranslationConfig:
         self.report_interval = report_interval
         self.min_text_length = min_text_length
         self.use_alternating_pages_dual = use_alternating_pages_dual
+        self.use_paper_title = use_paper_title
 
         # for backward compatibility
         if use_side_by_side_dual is False and use_alternating_pages_dual is False:

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ wheels = [
 
 [[package]]
 name = "babeldoc"
-version = "0.1.25"
+version = "0.1.31"
 source = { editable = "." }
 dependencies = [
     { name = "bitstring" },


### PR DESCRIPTION

- Introduce `--paper` CLI option to extract and use paper title in translation
- Implement paper title extraction in ParagraphFinder
- Create PaperTranslator to enhance translation context for OpenAI-compatible models
- Update documentation with new translation option details

---
It broke in typesetting phase and I have no idea how to fix it.

But it successfully read title from the paper!

Also I'm not satisfied with the current implementation, it's a bit hacky, maybe you can help restructure it better :)
```
❯ uv run babeldoc -c ~/.config/babelocr/config.toml --files '/Users/ccyynn/Downloads/41344.pdf' --paper
[03/11/25 18:03:02] INFO     INFO:babeldoc.docvision.doclayout:Loading ONNX model...                                              doclayout.py:37
[03/11/25 18:03:03] INFO     INFO:babeldoc.high_level:start to translate: /Users/ccyynn/Downloads/41344.pdf                     high_level.py:293
[03/11/25 18:03:12] INFO     INFO:babeldoc.high_level:Using paper title in translation: F1: A Distributed SQL Database That     high_level.py:379
                             Scales                                                                                                              
[03/11/25 18:03:13] WARNING  WARNING:babeldoc.document_il.utils.fontmap:Can't find font for 􏰁(1113089). Original font:             fontmap.py:163
                             PdfFont(name='ISWWRL+CMR9', font_id='F31', xref_id=7, encoding_length=1, bold=0, italic=0,                          
                             monospace=0, serif=1, ascent=694, descent=0). Char unicode: 􏰁.                                                      
                    WARNING  WARNING:babeldoc.progress_monitor:Stage Typesetting completed with 8/12 items                progress_monitor.py:103
                    ERROR    ERROR:babeldoc.high_level:translate error: 'NoneType' object has no attribute 'font_id'            high_level.py:453
                             Traceback (most recent call last):                                                                                  
                               File "/Users/ccyynn/repos/BabelDOC/babeldoc/high_level.py", line 417, in do_translate                             
                                 Typesetting(translation_config).typsetting_document(docs)                                                       
                               File "/Users/ccyynn/repos/BabelDOC/babeldoc/document_il/midend/typesetting.py", line 439, in                      
                             typsetting_document                                                                                                 
                                 self.render_page(page)                                                                                          
                               File "/Users/ccyynn/repos/BabelDOC/babeldoc/document_il/midend/typesetting.py", line 462, in                      
                             render_page                                                                                                         
                                 self.render_paragraph(paragraph, page, fonts)                                                                   
                               File "/Users/ccyynn/repos/BabelDOC/babeldoc/document_il/midend/typesetting.py", line 507, in                      
                             render_paragraph                                                                                                    
                                 typesetting_units = self.create_typesetting_units(paragraph, fonts)                                             
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                             
                               File "/Users/ccyynn/repos/BabelDOC/babeldoc/document_il/midend/typesetting.py", line 791, in                      
                             create_typesetting_units                                                                                            
                                 composition.pdf_same_style_unicode_characters.pdf_style.font_id                                                 
                             AttributeError: 'NoneType' object has no attribute 'font_id'                                                        
                    INFO     INFO:babeldoc.high_level:Waiting for translation to finish...                                      high_level.py:285
                    INFO     INFO:babeldoc.translation_config:cleanup temp files:                                       translation_config.py:180
                             /var/folders/q2/gcx5tz297n30c6f96lwmcr8w0000gn/T/tmpnbk4v2xa                                                        
translate                                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸━━━  92/100 0:00:10 0:00:00
Parse PDF and Create Intermediate Representation ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12/12   0:00:00 0:00:00
DetectScannedFile                                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12/12   0:00:00 0:00:00
Parse Page Layout                                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12/12   0:00:06 0:00:00
Parse Paragraphs                                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12/12   0:00:01 0:00:00
Parse Formulas and Styles                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12/12   0:00:00 0:00:00
Remove Char Descent                              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12/12   0:00:00 0:00:00
Translate Paragraphs                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 189/189 0:00:00 0:00:00
Typesetting                                      ━━━━━━━━━━━━━━━━━━━━╺━━━━━━━━━━━━━━━━━━━  6/12   0:00:00 0:00:01
                    ERROR    ERROR:asyncio:Future exception was never retrieved                                               base_events.py:1833
                             future: <Future finished exception=AttributeError("'NoneType' object has no attribute                               
                             'font_id'")>                                                                                                        
                             Traceback (most recent call last):                                                                                  
                               File                                                                                                              
                             "/nix/store/wwqdmdr2f5wrjnsjs64bny8df471rh9b-python3-3.12.9/lib/python3.12/concurrent/futures/th                    
                             read.py", line 59, in run                                                                                           
                                 result = self.fn(*self.args, **self.kwargs)                                                                     
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                     
                               File "/Users/ccyynn/repos/BabelDOC/babeldoc/high_level.py", line 417, in do_translate                             
                                 Typesetting(translation_config).typsetting_document(docs)                                                       
                               File "/Users/ccyynn/repos/BabelDOC/babeldoc/document_il/midend/typesetting.py", line 439, in                      
                             typsetting_document                                                                                                 
                                 self.render_page(page)                                                                                          
                               File "/Users/ccyynn/repos/BabelDOC/babeldoc/document_il/midend/typesetting.py", line 462, in                      
                             render_page                                                                                                         
                                 self.render_paragraph(paragraph, page, fonts)                                                                   
                               File "/Users/ccyynn/repos/BabelDOC/babeldoc/document_il/midend/typesetting.py", line 507, in                      
                             render_paragraph                                                                                                    
                                 typesetting_units = self.create_typesetting_units(paragraph, fonts)                                             
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                             
                               File "/Users/ccyynn/repos/BabelDOC/babeldoc/document_il/midend/typesetting.py", line 791, in                      
                             create_typesetting_units                                                                                            
                                 composition.pdf_same_style_unicode_characters.pdf_style.font_id                                                 
                             AttributeError: 'NoneType' object has no attribute 'font_id'
```