### PR TITLE
perf(doclayout): use `get_avalible_provider` for faster execution

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ wheels = [
 
 [[package]]
 name = "babeldoc"
-version = "0.2.1"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "bitstring" },


### PR DESCRIPTION
- Also used `os.cpu_count` as batch size
- also updated version in uv.lock

---
API:
https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.get_available_providers
> The order of elements represents the default priority order of Execution Providers from highest to lowest.



# Benchmark:
For a 20 pages pdf, on m1 macbook air 16 g

Before: 
```
translate                                        ━━━━━━╺━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  15/100 0:00:19 0:01:07
Parse PDF and Create Intermediate Representation ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 20/20   0:00:01 0:00:00
DetectScannedFile                                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 20/20   0:00:00 0:00:00
Parse Page Layout                                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 20/20   0:00:14 0:00:00
Parse Paragraphs                                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 20/20   0:00:01 0:00:00
Parse Formulas and Styles                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 20/20   0:00:00 0:00:00
Translate Paragraphs                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0/178 0:00:01 -:--:--
```

After: 
```
translate                                        ━━━━━━╺━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  15/100 0:00:13 0:00:42
Parse PDF and Create Intermediate Representation ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 20/20   0:00:01 0:00:00
DetectScannedFile                                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 20/20   0:00:00 0:00:00
Parse Page Layout                                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 20/20   0:00:07 0:00:00
Parse Paragraphs                                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 20/20   0:00:01 0:00:00
Parse Formulas and Styles                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 20/20   0:00:00 0:00:00
Translate Paragraphs                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0/178 0:00:01 -:--:--
```

It also eliminates the need to fill providers by hand.