### PR TITLE
fix(typeseeting): Better spacing of Japanese and Korean

### DIFF
--- a/babeldoc/document_il/midend/typesetting.py
+++ b/babeldoc/document_il/midend/typesetting.py
@@ -148,7 +148,7 @@ class TypesettingUnit:
         return True
 
     @property
-    def is_chinese_char(self):
+    def is_cjk_char(self):
         if self.formular:
             return False
         unicode = self.try_get_unicode()
@@ -185,14 +185,17 @@ class TypesettingUnit:
         ]:
             return True
         if unicode:
-            try:
-                unicodedata_name = unicodedata.name(unicode)
-                return (
-                    "CJK UNIFIED IDEOGRAPH" in unicodedata_name
-                    or "FULLWIDTH" in unicodedata_name
-                )
-            except ValueError:
-                return False
+            o = ord(unicode)
+            return (
+                0x1100 <= o <= 0x11ff # Hangul Jamo
+                or 0x2e80 <= o <= 0x9fff # CJKs
+                or 0xa960 <= o <= 0xa97f # Hangul Jamo Extended-A
+                or 0xac00 <= o <= 0xd7ff # Hanguls
+                or 0xf900 <= o <= 0xfaff # CJK Compatibility Ideographs
+                or 0x1aff0 <= o <= 0x1b16f # Kana extended, supplement, extension
+                or 0x1f200 <= o <= 0x1f2ff # Enclosed Ideographic Supplement
+                or 0x20000 <= o <= 0x323af # CJK Unified Ideographs Extensions
+            )
         return False
 
     @property
@@ -696,7 +699,7 @@ class Typesetting:
 
             if (
                 last_unit  # 有上一个单元
-                and last_unit.is_chinese_char ^ unit.is_chinese_char  # 中英文交界处
+                and last_unit.is_cjk_char ^ unit.is_cjk_char  # 中英文交界处
                 and (
                     last_unit.box
                     and last_unit.box.y


### PR DESCRIPTION
- Replaces is_chinese_char by is_cjk_char wich returns True also for Japanese and Korean chars
- Use is_cjk_char to fix spaces between East Asian languages and the others

Hi, I use BabelDOC for English to Japanese document translation and found some glitches in Japanese typesetting: non required spaces are added between Chinese letters and Japanese kanas. For example, here is a translation of "The quick brown fox jumps over the lazy dog" into Japanese:

[test.jp.dual.pdf](https://github.com/user-attachments/files/19969542/test.jp.dual.pdf)
![Screenshot 2025-04-30 at 10 14 10](https://github.com/user-attachments/assets/7d2e0e32-a4f9-4fbb-a762-58127b93e859)

We do not put spaces between Chinese and kana letters like above, and this patch fixes it.  The same translation with this patch:
[test2.jp.dual.pdf](https://github.com/user-attachments/files/19969562/test2.jp.dual.pdf)
![Screenshot 2025-04-30 at 10 16 34](https://github.com/user-attachments/assets/c2a73774-ef23-4f62-8cfa-e34d3e45d271)

which looks better.

I do not read Korean therefore not very sure but according to old Korean newspapers they do not seem to put spaces between Chinese and Hangul letters either.