### PR TITLE
fix(layout): use "relative font size" instead of "absolute 1pt".

### DIFF
--- a/babeldoc/format/pdf/converter.py
+++ b/babeldoc/format/pdf/converter.py
@@ -350,7 +350,7 @@ class TranslateConverter(PDFConverterEx):
                 # 当前字符不属于公式或当前字符是公式的第一个字符
                 if not vstk:
                     if cls == xt_cls:               # 当前字符与前一个字符属于同一段落
-                        if child.x0 > xt.x1 + 1:    # 添加行内空格
+                        if child.x0 > xt.x1 + max(1, 0.25 * child.size):    # 添加行内空格
                             sstk[-1] += " "
                         elif child.x1 < xt.x0:      # 添加换行空格并标记原文段落存在换行
                             sstk[-1] += " "


### PR DESCRIPTION
Using "absolute 1pt" to determine spaces does not accommodate the spacing of the headline.

eg:
L A RG E L I N G U I S T I C M O D E L S ...

<img width="688" height="363" alt="image" src="https://github.com/user-attachments/assets/a5ee56e0-67db-4f2b-9502-c8d63ca5ab09" />
[2305.00948.pdf](https://github.com/user-attachments/files/24091233/2305.00948.pdf)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect inline spaces using a threshold relative to font size instead of a fixed 1pt. This fixes spacing in headings with wide letter tracking, preventing incorrect spaces.

<sup>Written for commit ec3cbbe61a6e59ddf57557be5801e011572e181e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

