### PR TITLE
Revert "fix(layout): use "relative font size" instead of "absolute 1pt"."

### DIFF
--- a/babeldoc/format/pdf/converter.py
+++ b/babeldoc/format/pdf/converter.py
@@ -350,7 +350,7 @@ class TranslateConverter(PDFConverterEx):
                 # 当前字符不属于公式或当前字符是公式的第一个字符
                 if not vstk:
                     if cls == xt_cls:               # 当前字符与前一个字符属于同一段落
-                        if child.x0 > xt.x1 + max(1, 0.25 * child.size):    # 添加行内空格
+                        if child.x0 > xt.x1 + 1:    # 添加行内空格
                             sstk[-1] += " "
                         elif child.x1 < xt.x0:      # 添加换行空格并标记原文段落存在换行
                             sstk[-1] += " "


### PR DESCRIPTION
Reverts funstory-ai/BabelDOC#549

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches inline space detection back to a fixed 1pt gap in the PDF converter. Restores the previous layout behavior and prevents inconsistent spacing caused by the relative font-size threshold.

<sup>Written for commit da7cdfb8b226827db9ee75bcba92e43006dddae4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

