### PR TITLE
Add a (off-by-default) option to disable same input output fallback, update logging format

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ uv run babeldoc --files example.pdf --files example2.pdf --openai --openai-model
 - `--openai`: Use OpenAI for translation (default: False)
 - `--custom-system-prompt`: Custom system prompt for translation.
 - `--add-formula-placehold-hint`: Add formula placeholder hint for translation. (Currently not recommended, it may affect translation quality, default: False)
+- `--disable-same-text-fallback`: Disable fallback translation when LLM output matches input text. (default: False)
 - `--pool-max-workers`: Maximum number of worker threads for internal task processing pools. If not specified, defaults to QPS value. This parameter directly sets the worker count, replacing previous QPS-based dynamic calculations.
 - `--no-auto-extract-glossary`: Disable automatic term extraction. If this flag is present, the step is skipped. Defaults to enabled.
 
@@ -305,6 +306,7 @@ openai-model = "gpt-4o-mini"
 openai-base-url = "https://api.openai.com/v1"
 openai-api-key = "your-api-key-here"
 enable-json-mode-if-requested = false  # Enable JSON mode when requested (default: false)
+disable_same_text_fallback = false # Disable fallback translation when LLM output matches input text (default: false)
 pool-max-workers = 8  # Maximum worker threads for task processing (defaults to QPS value if not set)
 
 # Glossary Options (Optional)

--- a/babeldoc/format/pdf/translation_config.py
+++ b/babeldoc/format/pdf/translation_config.py
@@ -199,6 +199,7 @@ class TranslationConfig:
         term_extraction_translator: BaseTranslator | None = None,
         metadata_extra_data: str | None = None,
         term_pool_max_workers: int | None = None,
+        disable_same_text_fallback: bool = False,
     ):
         self.translator = translator
         self.term_extraction_translator = term_extraction_translator or translator
@@ -354,6 +355,7 @@ class TranslationConfig:
             "completion_tokens": 0,
             "cache_hit_prompt_tokens": 0,
         }
+        self.disable_same_text_fallback = disable_same_text_fallback
 
         if self.ocr_workaround:
             self.remove_non_formula_lines = False

--- a/babeldoc/main.py
+++ b/babeldoc/main.py
@@ -270,6 +270,12 @@ def create_parser():
         help="Add formula placeholder hint for translation. (Currently not recommended, it may affect translation quality, default: False)",
     )
     translation_group.add_argument(
+        "--disable-same-text-fallback",
+        action="store_true",
+        default=False,
+        help="Disable fallback translation when LLM output matches input text. (default: False)",
+    )
+    translation_group.add_argument(
         "--glossary-files",
         type=str,
         default=None,
@@ -703,6 +709,7 @@ async def main():
             custom_system_prompt=args.custom_system_prompt,
             working_dir=working_dir,
             add_formula_placehold_hint=args.add_formula_placehold_hint,
+            disable_same_text_fallback=args.disable_same_text_fallback,
             glossaries=loaded_glossaries,
             pool_max_workers=args.pool_max_workers,
             auto_extract_glossary=args.auto_extract_glossary,

--- a/uv.lock
+++ b/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "babeldoc"
-version = "0.5.21"
+version = "0.5.22"
 source = { editable = "." }
 dependencies = [
     { name = "bitstring" },


### PR DESCRIPTION
### Related Issue(s)

<!-- If this PR closes or is related to one or more issues, please list them here (e.g., #37) -->
<!-- e.g.: Closes #37, Relates to #42 -->
#554 

### Motivation and Context

Added a off-by-default option to disable same input output fallback
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Summary of Changes

<!-- What does this PR introduce or fix? Please describe concisely. -->
1. Add option to disable fallback on same input output, as well as edit distance check as they conflict with each other
2. Update docs and version
3. Enhance logging for translation length validation with input and output previews (Could be dropped if not needed, but I think the previous error message is not meaningful)

### PR Type

<!-- What kind of change is this? Please select one or more -->
- [x] ✨ Enhancement


### Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe them. -->
<!-- - [ ] Yes, this PR introduces breaking changes.
<!-- - [ ] No, this PR does not introduce breaking changes. -->
<!-- Detailed description of breaking changes (if any): -->
[x] No, this PR does not introduce breaking changes, as it's off by default

### Contributor Checklist

- [x] I have fully read and understood the **[CONTRIBUTING.md](https://funstory-ai.github.io/BabelDOC/CONTRIBUTING/)** guide.
- [x] I have performed a self-review of my own code.
- [x] My changes follow the project's code style and guidelines
- [x] I have linked the related issue(s) in the description above (if applicable)
- [x] I have updated relevant documentation (if applicable)
- [x] I have added necessary tests that prove my fix is effective or that my feature works (if applicable)
- [x] All new and existing tests passed locally with my changes
- [x] My changes generate no new warnings or errors
- [x] I understand that due to limited maintainer resources, only small PRs are accepted. Suggestions with proof-of-concept patches are appreciated, and my patch may be rewritten if necessary.

### Testing Instructions

<!-- Please provide clear and concise step-by-step instructions on how to test your changes. -->
<!-- e.g.: -->
<!-- 1. Check out this branch. -->
<!-- 2. Run `...` to install dependencies. -->
<!-- 3. Run `...` to start the application/run the script. -->
<!-- 4. Navigate to `...` or observe `...` -->
<!-- 5. Verify that `...` (expected outcome). -->

### Screenshots (if applicable)

<!-- If your changes include UI modifications, please add screenshots or GIFs to show the before and after. -->

### Additional Notes

<!-- Is there anything else the reviewer should know? For example, any dependencies, or potential impacts. --> 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an off-by-default option to disable the “same input = same output” fallback and improves translation length logging. Addresses #554 by letting users keep literal text when needed and reducing unexpected fallbacks.

- **New Features**
  - CLI flag: --disable-same-text-fallback
  - Config: disable_same_text_fallback
  - When enabled, identical-text and small edit-distance fallbacks are skipped.
  - Enhanced length check logging with token counts and input/output previews.

- **Dependencies**
  - Bumped babeldoc to 0.5.22.
  - Updated README with new CLI and config options.

<sup>Written for commit 43ceda3c3acd502ac5e76469262587621a866d17. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



