### PR TITLE
Security & Performance Fixes

### DIFF
--- a/babeldoc/const.py
+++ b/babeldoc/const.py
@@ -13,6 +13,10 @@ CACHE_FOLDER = Path.home() / ".cache" / "babeldoc"
 
 def get_cache_file_path(filename: str, sub_folder: str | None = None) -> Path:
     if sub_folder is not None:
+        # Prevent path traversal attacks - only allow safe folder names
+        import re
+        if not re.match(r'^[a-zA-Z0-9_-]+$', sub_folder):
+            raise ValueError(f"Invalid sub_folder name: {sub_folder}")
         sub_folder = sub_folder.strip("/")
         sub_folder_path = CACHE_FOLDER / sub_folder
         sub_folder_path.mkdir(parents=True, exist_ok=True)

--- a/babeldoc/format/pdf/document_il/midend/layout_parser.py
+++ b/babeldoc/format/pdf/document_il/midend/layout_parser.py
@@ -168,7 +168,8 @@ class LayoutParser:
                 # self.generate_fallback_line_layout_for_page(page)
                 # self._save_debug_box_to_page(page)
                 progress.advance(1)
-            with ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
+            max_workers = min(os.cpu_count() or 1, 8)
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 for page in docs.page:
                     executor.submit(
                         self.generate_fallback_line_layout_for_page, page, progress

--- a/babeldoc/format/pdf/high_level.py
+++ b/babeldoc/format/pdf/high_level.py
@@ -14,6 +14,8 @@ from typing import Any
 from typing import BinaryIO
 
 import pymupdf
+
+_RE_SURROGATES = re.compile(r"[\uD800-\uDFFF]")
 from pymupdf import Document
 from pymupdf import Font
 
@@ -155,7 +157,7 @@ def add_metadata(
         for k, v in meta.items():
             if v:
                 # 使用正则替换掉 surrogate 范围内的字符
-                meta[k] = re.sub(r"[\uD800-\uDFFF]", "", v)
+                meta[k] = _RE_SURROGATES.sub("", v)
 
         pdf.set_metadata(meta)
         safe_save(pdf, temp_path)

--- a/babeldoc/translator/translator.py
+++ b/babeldoc/translator/translator.py
@@ -173,20 +173,6 @@ class BaseTranslator(ABC):
         """
         raise NotImplementedError
 
-    @abstractmethod
-    def do_translate(self, text, rate_limit_params: dict = None):
-        """
-        Actual translate text, override this method
-        :param text: text to translate
-        :return: translated text
-        """
-        logger.critical(
-            f"Do not call BaseTranslator.do_translate. "
-            f"Translator: {self}. "
-            f"Text: {text}. ",
-        )
-        raise NotImplementedError
-
     def __str__(self):
         return f"{self.name} {self.lang_in} {self.lang_out} {self.model}"
 


### PR DESCRIPTION
This PR includes 4 security and performance improvements:

1. **Path Traversal Fix (babeldoc/const.py)**: Added regex validation to prevent path traversal attacks in `get_cache_file_path()`. Only allows safe folder names matching `^[a-zA-Z0-9_-]+$`.

2. **Compile Regex Once (babeldoc/format/pdf/high_level.py)**: Precompiled the surrogate character regex pattern `_RE_SURROGATES` at module level for better performance, instead of compiling it on every metadata processing call.

3. **Remove Dead Code (babeldoc/translator/translator.py)**: Removed unreachable duplicate `do_translate` abstract method that was declared after a `raise NotImplementedError`.

4. **Limit Thread Pool (babeldoc/format/pdf/document_il/midend/layout_parser.py)**: Capped the ThreadPoolExecutor max_workers at 8 to prevent resource exhaustion on systems with high CPU counts. Uses `min(os.cpu_count() or 1, 8)`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix path traversal in cache file handling, improve PDF metadata processing, and cap thread pool size to prevent resource spikes. Also removed dead code in the translator.

- **Bug Fixes**
  - Validate cache sub_folder with regex to block path traversal.

- **Performance**
  - Precompile surrogate regex and reuse in add_metadata.
  - Limit ThreadPoolExecutor to max 8 workers in layout_parser.

<sup>Written for commit b068455bb01da6b4bf7e5fab14cd47fc2e326cf1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

