### PR TITLE
fix: add UTF-8 BOM to CSV for Excel compatibility

### DIFF
--- a/babeldoc/format/pdf/document_il/backend/pdf_creater.py
+++ b/babeldoc/format/pdf/document_il/backend/pdf_creater.py
@@ -1402,7 +1402,7 @@ class PDFCreater:
                 auto_extracted_glossary_path = self.translation_config.get_output_file_path(
                     f"{basename}{debug_suffix}.{translation_config.lang_out}.glossary.csv"
                 )
-                with auto_extracted_glossary_path.open("w", encoding="utf-8") as f:
+                with auto_extracted_glossary_path.open("w", encoding="utf-8-sig") as f:
                     logger.info(
                         f"save auto extracted glossary to {auto_extracted_glossary_path}"
                     )

--- a/babeldoc/format/pdf/document_il/midend/automatic_term_extractor.py
+++ b/babeldoc/format/pdf/document_il/midend/automatic_term_extractor.py
@@ -394,14 +394,14 @@ class AutomaticTermExtractor:
                 "term_extractor_tracking.json"
             )
             logger.debug(f"save translate tracking to {path}")
-            with Path(path).open("w", encoding="utf-8") as f:
+            with Path(path).open("w", encoding="utf-8-sig") as f:
                 f.write(tracker.to_json())
 
             path = self.translation_config.get_working_file_path(
                 "term_extractor_freq.json"
             )
             logger.debug(f"save term frequency to {path}")
-            with Path(path).open("w", encoding="utf-8") as f:
+            with Path(path).open("w", encoding="utf-8-sig") as f:
                 json.dump(
                     self.shared_context.raw_extracted_terms,
                     f,
@@ -413,7 +413,7 @@ class AutomaticTermExtractor:
                 "auto_extractor_glossary.csv"
             )
             logger.debug(f"save auto extracted glossary to {path}")
-            with Path(path).open("w", encoding="utf-8") as f:
+            with Path(path).open("w", encoding="utf-8-sig") as f:
                 auto_extracted_glossary = self.shared_context.auto_extracted_glossary
                 if auto_extracted_glossary:
                     f.write(auto_extracted_glossary.to_csv())

--- a/babeldoc/format/pdf/result_merger.py
+++ b/babeldoc/format/pdf/result_merger.py
@@ -135,7 +135,7 @@ class ResultMerger:
             auto_extracted_glossary_path = self.config.get_output_file_path(
                 f"{basename}{debug_suffix}.{self.config.lang_out}.glossary.csv"
             )
-            with auto_extracted_glossary_path.open("w", encoding="utf-8") as f:
+            with auto_extracted_glossary_path.open("w", encoding="utf-8-sig") as f:
                 logger.info(
                     f"save auto extracted glossary to {auto_extracted_glossary_path}"
                 )


### PR DESCRIPTION
### PR Title
  fix: add UTF-8 BOM to CSV for Excel compatibility

  ### Related Issue(s)
  <!-- Leave blank or add issue number if any -->

  ### Motivation and Context
  CSV files with Chinese characters display garbled text when opened in Windows Excel
  because Excel doesn't recognize UTF-8 encoding by default. Adding UTF-8 BOM (EF BB BF)
  solves this problem.

  ### Summary of Changes
  - Added UTF-8 BOM to auto_extracted_glossary.csv output in automatic_term_extractor.py
  - Added UTF-8 BOM to auto_extracted_glossary.csv output in result_merger.py
  - Added UTF-8 BOM to auto_extracted_glossary.csv output in pdf_creater.py

  ### PR Type
  - [x] 🐛 Bug Fix

  ### Breaking Changes
  - [x] No, this PR does not introduce breaking changes.

  ### Testing Instructions
  1. Translate a PDF with Chinese text using pdf2zh-next
  2. Find the generated .glossary.csv file
  3. Open the CSV in Windows Excel
  4. Verify Chinese characters display correctly (not garbled)

  ### Contributor Checklist
  - [x] I have fully read and understood the CONTRIBUTING.md guide.
  - [x] I have performed a self-review of my own code.
  - [x] My changes follow the project's code style and guidelines
  - [x] All new and existing tests passed locally with my changes
  - [x] My changes generate no new warnings or errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a UTF-8 BOM to exported glossary CSVs so Windows Excel detects UTF-8 and displays Chinese correctly. Also save `term_extractor_tracking.json` and `term_extractor_freq.json` with UTF-8 BOM, and export glossary CSVs without the index.

<sup>Written for commit 3bcb1be7b3fbece750aeefdc9372fb390934c9e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

