### PR TITLE
[PR] prevent/reduce layout oscillation

### DIFF
--- a/babeldoc/format/pdf/document_il/midend/paragraph_finder.py
+++ b/babeldoc/format/pdf/document_il/midend/paragraph_finder.py
@@ -435,7 +435,8 @@ class ParagraphFinder:
         prev_width = max(prev_box.x2 - prev_box.x, 1)
         curr_width = max(curr_box.x2 - curr_box.x, 1)
         tolerance = max(prev_width, curr_width) * 2
-        normal_horizontal_flow = curr_box.x >= prev_box.x - tolerance
+        horizontal_jump = curr_box.x - prev_box.x
+        normal_horizontal_flow = abs(horizontal_jump) <= tolerance
 
         if (
             same_line

--- a/babeldoc/format/pdf/document_il/midend/paragraph_finder.py
+++ b/babeldoc/format/pdf/document_il/midend/paragraph_finder.py
@@ -25,7 +25,9 @@ from babeldoc.format.pdf.document_il.utils.layout_helper import Layout
 from babeldoc.format.pdf.document_il.utils.layout_helper import add_space_dummy_chars
 from babeldoc.format.pdf.document_il.utils.layout_helper import build_layout_index
 from babeldoc.format.pdf.document_il.utils.layout_helper import calculate_iou_for_boxes
-from babeldoc.format.pdf.document_il.utils.layout_helper import calculate_y_iou_for_boxes
+from babeldoc.format.pdf.document_il.utils.layout_helper import (
+    calculate_y_iou_for_boxes
+)
 from babeldoc.format.pdf.document_il.utils.layout_helper import get_char_unicode_string
 from babeldoc.format.pdf.document_il.utils.layout_helper import get_character_layout
 from babeldoc.format.pdf.document_il.utils.layout_helper import is_bullet_point
@@ -398,6 +400,18 @@ class ParagraphFinder:
         current_layout: Layout | None,
         new_layout: Layout | None,
     ) -> bool:
+        """Decide whether a layout change should start a new paragraph.
+
+        Args:
+            prev_char: The previous character in the current paragraph.
+            curr_char: The current character being processed.
+            current_layout: The layout currently assigned to the paragraph.
+            new_layout: The layout assigned to the current character.
+
+        Returns:
+            True if the layout change looks like a structural break and should
+            start a new paragraph, otherwise False.
+        """
         if (
             prev_char is None
             or current_layout is None
@@ -522,7 +536,9 @@ class ParagraphFinder:
                 )
                 and char.char_unicode not in HEIGHT_NOT_USFUL_CHAR_IN_CHAR
             ):
-                xobj_changed = prev_char is not None and prev_char.xobj_id != char.xobj_id
+                xobj_changed = (
+                    prev_char is not None and prev_char.xobj_id != char.xobj_id
+                )
                 layout_changed = (
                     current_layout is not None
                     and char_layout.id != current_layout.id

--- a/babeldoc/format/pdf/document_il/midend/paragraph_finder.py
+++ b/babeldoc/format/pdf/document_il/midend/paragraph_finder.py
@@ -25,6 +25,7 @@ from babeldoc.format.pdf.document_il.utils.layout_helper import Layout
 from babeldoc.format.pdf.document_il.utils.layout_helper import add_space_dummy_chars
 from babeldoc.format.pdf.document_il.utils.layout_helper import build_layout_index
 from babeldoc.format.pdf.document_il.utils.layout_helper import calculate_iou_for_boxes
+from babeldoc.format.pdf.document_il.utils.layout_helper import calculate_y_iou_for_boxes
 from babeldoc.format.pdf.document_il.utils.layout_helper import get_char_unicode_string
 from babeldoc.format.pdf.document_il.utils.layout_helper import get_character_layout
 from babeldoc.format.pdf.document_il.utils.layout_helper import is_bullet_point
@@ -390,6 +391,48 @@ class ParagraphFinder:
             and a.xobj_id == c.xobj_id
         )
 
+    @staticmethod
+    def _should_split_on_layout_change(
+        prev_char: PdfCharacter | None,
+        curr_char: PdfCharacter,
+        current_layout: Layout | None,
+        new_layout: Layout | None,
+    ) -> bool:
+        if (
+            prev_char is None
+            or current_layout is None
+            or new_layout is None
+            or current_layout.id == new_layout.id
+        ):
+            return True
+
+        if prev_char.xobj_id != curr_char.xobj_id:
+            return True
+
+        prev_box = prev_char.visual_bbox.box
+        curr_box = curr_char.visual_bbox.box
+
+        y_overlap = max(
+            calculate_y_iou_for_boxes(prev_box, curr_box),
+            calculate_y_iou_for_boxes(curr_box, prev_box),
+        )
+        same_line = y_overlap > 0.6
+
+        prev_width = max(prev_box.x2 - prev_box.x, 1)
+        curr_width = max(curr_box.x2 - curr_box.x, 1)
+        tolerance = max(prev_width, curr_width) * 2
+        normal_horizontal_flow = curr_box.x >= prev_box.x - tolerance
+
+        if (
+            same_line
+            and normal_horizontal_flow
+            and is_text_layout(current_layout)
+            and is_text_layout(new_layout)
+        ):
+            return False
+
+        return True
+
     def merge_alternating_line_number_paragraphs(self, paragraphs: list[PdfParagraph]):
         # a 代表正文
         # l 代表行号
@@ -462,6 +505,12 @@ class ParagraphFinder:
             char_area = (char_box.x2 - char_box.x) * (char_box.y2 - char_box.y)
             is_small_char = char_area < median_char_area * 0.05
 
+            prev_char = None
+            if current_paragraph and current_paragraph.pdf_paragraph_composition:
+                prev_char = current_paragraph.pdf_paragraph_composition[
+                    -1
+                ].pdf_character
+
             is_new_paragraph = False
             if current_paragraph is None:
                 is_new_paragraph = True
@@ -473,22 +522,24 @@ class ParagraphFinder:
                 )
                 and char.char_unicode not in HEIGHT_NOT_USFUL_CHAR_IN_CHAR
             ):
-                if (
-                    (
-                        char_layout.id != current_layout.id
-                        and not SPACE_REGEX.match(char.char_unicode)
-                    )
-                    or (  # not same xobject
-                        current_paragraph.pdf_paragraph_composition
-                        and current_paragraph.pdf_paragraph_composition[
-                            -1
-                        ].pdf_character.xobj_id
-                        != char.xobj_id
-                    )
-                    or (
-                        is_bullet_point(char)
-                        and not current_paragraph.pdf_paragraph_composition
-                    )
+                xobj_changed = prev_char is not None and prev_char.xobj_id != char.xobj_id
+                layout_changed = (
+                    current_layout is not None
+                    and char_layout.id != current_layout.id
+                    and not SPACE_REGEX.match(char.char_unicode)
+                )
+                bullet_starts_paragraph = (
+                    is_bullet_point(char)
+                    and not current_paragraph.pdf_paragraph_composition
+                )
+
+                if xobj_changed or bullet_starts_paragraph:
+                    is_new_paragraph = True
+                elif layout_changed and self._should_split_on_layout_change(
+                    prev_char,
+                    char,
+                    current_layout,
+                    char_layout,
                 ):
                     is_new_paragraph = True
 


### PR DESCRIPTION
### PR Title

<!-- Please fill in a concise and clear PR title below -->
[PR] <Your concise title here>

### Motivation and Context

`paragraph_finder` groups characters into paragraphs partly based on their detected layout ID.

Problem: In some PDFs, adjacent characters from the same visual text line are assigned to two      
 different layout regions in an alternating pattern, for example layout 10, then 16, then 10, then 16.  

Because _group_characters_into_paragraphs() treated a layout change as a hard paragraph boundary, this caused the text to be split into many tiny paragraphs, sometimes even one character per paragraph.

This means: Alternating layout assignments for neighboring characters caused false paragraph breaks.   


### Summary of Changes

 The fix introduces a kind of hysteresis into paragraph grouping. The the current paragraph state is more “sticky”:      
 
 We check  
 - if the layout changes,                                                                                                                                                                                            
 - but the new character is still likely part of the same text flow,                                                                                                                                                 
 - then we do not start a new paragraph.   
 
 The new logic checks whether:                                                                                                                                                                                       
                                                                                                                                                                                                                     
 1. the previous character and current character belong to the same XObject                                                                                                                                          
 2. their bounding boxes strongly overlap in the vertical direction, meaning they are likely on the same line                                                                                                        
 3. the horizontal movement still looks normal for continuous text                                                                                                                                                   
 4. both old and new layouts are still text layouts                                    
<!-- What does this PR introduce or fix? Please describe concisely. -->

### PR Type


- [x ] 🐛 Bug Fix

### Breaking Changes

Should contain none - unless there exists documents in which single characters alternate between two layout regions and belong to a new paragraph each.

### Contributor Checklist

- [ x] I have fully read and understood the **[CONTRIBUTING.md](https://funstory-ai.github.io/BabelDOC/CONTRIBUTING/)** guide.
- [x] I have performed a self-review of my own code.
- [x] My changes follow the project's code style and guidelines (
- [n/a] I have linked the related issue(s) in the description above (if applicable)
- [n/a ] I have updated relevant documentation (if applicable)
- [x] I have added necessary tests that prove my fix is effective or that my feature works (if applicable)
[test.pdf](https://github.com/user-attachments/files/26568540/test.pdf) 

- [x] All new and existing tests passed locally with my changes
- [x] My changes generate no new warnings or errors
- [x] I understand that due to limited maintainer resources, only small PRs are accepted. Suggestions with proof-of-concept patches are appreciated, and my patch may be rewritten if necessary.

### Testing Instructions

Translating the attached pdf resulted in broken paragraphs, after the fix the pdf is correct.
<img width="898" height="538" alt="grafik" src="https://github.com/user-attachments/assets/26836da3-8401-4e0c-96bd-65b8ba9eaae2" />
(translated from english to en-gb :-) )




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce false paragraph breaks by making layout-change splits “sticky” in PDF paragraph grouping. Adds a symmetric horizontal bound and stronger same-line checks to stop tiny, one-character paragraphs from alternating layout IDs.

- **Bug Fixes**
  - Added `_should_split_on_layout_change` to ignore harmless layout flips when characters share the same XObject, have strong vertical overlap (via `calculate_y_iou_for_boxes`), both layouts are text layouts, and horizontal movement stays within a symmetric tolerance based on character width.
  - Updated `_group_characters_into_paragraphs` to only split on structural changes; still starts new paragraphs for XObject changes and bullets.

<sup>Written for commit 5210d0813dab1d7306921d4df1c0df25649915e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

