### PR TITLE
Make LLM batch translation thresholds configurable to reduce API calls for multi-page PDFs

### DIFF
--- a/babeldoc/format/pdf/document_il/midend/il_translator_llm_only.py
+++ b/babeldoc/format/pdf/document_il/midend/il_translator_llm_only.py
@@ -589,7 +589,7 @@ class ILTranslatorLLMOnly:
                     )
                 )
 
-            if total_token_count > 200 or len(paragraphs) > 5:
+            if total_token_count > self.translation_config.llm_batch_max_tokens or len(paragraphs) > self.translation_config.llm_batch_max_paragraphs:
                 self.mid += 1
                 executor.submit(
                     self.translate_paragraph,

--- a/babeldoc/format/pdf/translation_config.py
+++ b/babeldoc/format/pdf/translation_config.py
@@ -217,8 +217,8 @@ class TranslationConfig:
         metadata_extra_data: str | None = None,
         term_pool_max_workers: int | None = None,
         disable_same_text_fallback: bool = False,
-        llm_batch_max_tokens: int = 2000,
-        llm_batch_max_paragraphs: int = 30,
+        llm_batch_max_tokens: int = 200,
+        llm_batch_max_paragraphs: int = 5,
     ):
         self.translator = translator
         self.term_extraction_translator = term_extraction_translator or translator

--- a/babeldoc/format/pdf/translation_config.py
+++ b/babeldoc/format/pdf/translation_config.py
@@ -217,6 +217,8 @@ class TranslationConfig:
         metadata_extra_data: str | None = None,
         term_pool_max_workers: int | None = None,
         disable_same_text_fallback: bool = False,
+        llm_batch_max_tokens: int = 2000,
+        llm_batch_max_paragraphs: int = 30,
     ):
         self.translator = translator
         self.term_extraction_translator = term_extraction_translator or translator
@@ -376,6 +378,8 @@ class TranslationConfig:
             "cache_hit_prompt_tokens": 0,
         }
         self.disable_same_text_fallback = disable_same_text_fallback
+        self.llm_batch_max_tokens = llm_batch_max_tokens
+        self.llm_batch_max_paragraphs = llm_batch_max_paragraphs
 
         if self.ocr_workaround:
             self.remove_non_formula_lines = False

--- a/babeldoc/main.py
+++ b/babeldoc/main.py
@@ -294,14 +294,14 @@ def create_parser():
     translation_group.add_argument(
         "--llm-batch-max-tokens",
         type=int,
-        default=2000,
-        help="Maximum total tokens per LLM batch translation request. Paragraphs are packed until this limit is reached. (default: 2000)",
+        default=200,
+        help="Maximum total tokens per LLM batch translation request. Paragraphs are packed until this limit is reached. (default: 200)",
     )
     translation_group.add_argument(
         "--llm-batch-max-paragraphs",
         type=int,
-        default=30,
-        help="Maximum number of paragraphs per LLM batch translation request. Paragraphs are packed until this limit is reached. (default: 30)",
+        default=5,
+        help="Maximum number of paragraphs per LLM batch translation request. Paragraphs are packed until this limit is reached. (default: 5)",
     )
     translation_group.add_argument(
         "--no-auto-extract-glossary",

--- a/babeldoc/main.py
+++ b/babeldoc/main.py
@@ -292,6 +292,18 @@ def create_parser():
         help="Maximum number of worker threads dedicated to automatic term extraction. If not specified, defaults to --pool-max-workers (or QPS value when unset).",
     )
     translation_group.add_argument(
+        "--llm-batch-max-tokens",
+        type=int,
+        default=2000,
+        help="Maximum total tokens per LLM batch translation request. Paragraphs are packed until this limit is reached. (default: 2000)",
+    )
+    translation_group.add_argument(
+        "--llm-batch-max-paragraphs",
+        type=int,
+        default=30,
+        help="Maximum number of paragraphs per LLM batch translation request. Paragraphs are packed until this limit is reached. (default: 30)",
+    )
+    translation_group.add_argument(
         "--no-auto-extract-glossary",
         action="store_false",
         dest="auto_extract_glossary",
@@ -729,6 +741,8 @@ async def main():
             skip_formula_offset_calculation=args.skip_formula_offset_calculation,
             metadata_extra_data=args.metadata_extra_data,
             term_pool_max_workers=args.term_pool_max_workers,
+            llm_batch_max_tokens=args.llm_batch_max_tokens,
+            llm_batch_max_paragraphs=args.llm_batch_max_paragraphs,
         )
 
         def nop(_x):


### PR DESCRIPTION
### PR Title

<!-- Please fill in a concise and clear PR title below -->
[PR] Make LLM batch translation thresholds configurable to reduce API calls for multi-page PDFs


### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Summary of Changes

<!-- What does this PR introduce or fix? Please describe concisely. -->
When translating multi-page PDFs, the LLM batch translation thresholds were hardcoded to 200 tokens or 5 paragraphs. This caused excessive fragmentation: a 30-page PDF with ~10 paragraphs per page would generate 90–150 individual LLM API calls. Each call incurs rate-limiter queuing, network round-trip time, and LLM inference overhead, making the translation of long documents unnecessarily slow.

### PR Type

<!-- What kind of change is this? Please select one or more -->
- [x] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor
- [ ] 🧪 Test
- [ ] 🧹 Chore

### Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe them. -->

- [x] No, this PR does not introduce breaking changes.

Default behavior now packs more paragraphs per LLM request, which may increase individual request latency but significantly reduces the total number of API calls. Users can tune the thresholds via CLI or config file to match their model's context window and desired latency profile.
<!-- Detailed description of breaking changes (if any): -->

### Contributor Checklist

- [x] I have fully read and understood the **[CONTRIBUTING.md](https://funstory-ai.github.io/BabelDOC/CONTRIBUTING/)** guide.
- [x] I have performed a self-review of my own code.
- [x] My changes follow the project's code style and guidelines
- [x] I have linked the related issue(s) in the description above (if applicable)
- [x] I have updated relevant documentation (if applicable)
- [x] I have added necessary tests that prove my fix is effective or that my feature works (if applicable)
- [x] All new and existing tests passed locally with my changes
- [x] My changes generate no new warnings or errors
- [x] I understand that due to limited maintainer resources, only small PRs are accepted. Suggestions with proof-of-concept patches are appreciated, and my patch may be rewritten if necessary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes LLM batch translation thresholds configurable to pack more paragraphs per request and cut API calls for multi-page PDFs. Defaults match previous behavior (200 tokens, 5 paragraphs), so you can opt in to larger batches as needed.

- **New Features**
  - Added `--llm-batch-max-tokens` and `--llm-batch-max-paragraphs` to control batch sizing.
  - PDF translator now reads limits from `TranslationConfig` instead of hardcoded values.
  - Raise thresholds to reduce requests on long PDFs based on your model’s context window and latency needs.

<sup>Written for commit d7e3c4f1230780d20ef1916add7822a083f2b279. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

